### PR TITLE
feature: use net471 as net47 can't be installed if net471 is installed first

### DIFF
--- a/Host.WPF/Host.WPF.csproj
+++ b/Host.WPF/Host.WPF.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Book</RootNamespace>
     <AssemblyName>Book</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ViewModels/ViewModels.csproj
+++ b/ViewModels/ViewModels.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <AssemblyName>Book.ViewModels</AssemblyName>
         <RootNamespace>Book.ViewModels</RootNamespace>
-        <TargetFrameworks>netstandard1.3;net47</TargetFrameworks>
+        <TargetFrameworks>netstandard1.3;net471</TargetFrameworks>
         <WarningsAsErrors>true</WarningsAsErrors>
         <LangVersion>latest</LangVersion>
 


### PR DESCRIPTION
It's possible to get stuck in a circular situation where the samples cannot be loaded. This fixes it.