### PR TITLE
Use culture specific decimal separator to prevent crash

### DIFF
--- a/ViewModels/Data/Serializers/PointSerializer.cs
+++ b/ViewModels/Data/Serializers/PointSerializer.cs
@@ -22,10 +22,13 @@ namespace Book.ViewModels.Data.Serializers
 
             var components = value
                 .Split(',');
+
+            var cultureInfo = System.Globalization.CultureInfo.GetCultureInfo("en-US");
+
             return new PointF
             {
-                X = float.Parse(components[0]),
-                Y = float.Parse(components[1])
+                X = float.Parse(components[0], cultureInfo),
+                Y = float.Parse(components[1], cultureInfo)
             };
         }
 


### PR DESCRIPTION
The sample app crashed on me when I accessed the Splat - Bitmaps sample for instance due to difference in number style (decimal point etc). 

This is a quick fix to prevent that from happening to others by specifying the culture that's expected.
